### PR TITLE
outputting \r makes output unreadable in journald

### DIFF
--- a/chkbit/main.py
+++ b/chkbit/main.py
@@ -39,7 +39,7 @@ class Main:
                 self.total += 1
             if self.verbose or not stat in [Stat.OK, Stat.SKIP]:
                 print(stat.value, path)
-            if not self.quiet:
+            if not self.quiet and sys.stdout.isatty():
                 print(self.total, end="\r")
 
     def _parse_args(self):


### PR DESCRIPTION
When running chkbit from a systemd service, chkbit output ends up in journald, which in turn thinks the output is a sequence of binary blobs, because of the presence of \r, journalctl -u bitchk:

Jan 23 13:52:49 myhostname chkbit[123]: [57B blob data]

Add tty detection, to keep the current behavior on an interactive tty, while leaving out the \r when the output is pipep into something else.