### PR TITLE
Added --skip-symlinks option

### DIFF
--- a/chkbit/context.py
+++ b/chkbit/context.py
@@ -2,12 +2,13 @@ import hashlib
 
 
 class Context:
-    def __init__(self, verify_index, update, force, hash_algo):
+    def __init__(self, verify_index, update, force, hash_algo, skip_symlinks):
 
         self.verify_index = verify_index
         self.update = update
         self.force = force
         self.hash_algo = hash_algo
+        self.skip_symlinks = skip_symlinks
 
         if hash_algo not in ["md5", "sha512"]:
             raise Exception(f"{hash_algo} is unknown.")

--- a/chkbit/indexthread.py
+++ b/chkbit/indexthread.py
@@ -31,7 +31,10 @@ class IndexThread:
             if name[0] == ".":
                 continue
             if os.path.isdir(path):
-                dirs.append(name)
+                if self.context.skip_symlinks and os.path.islink(path):
+                    pass
+                else:
+                    dirs.append(name)
             elif os.path.isfile(path):
                 files.append(name)
 

--- a/chkbit/main.py
+++ b/chkbit/main.py
@@ -82,6 +82,10 @@ class Main:
         )
 
         parser.add_argument(
+            "-s", "--skip-symlinks", action="store_true", help="do not follow symlinks"
+        )
+
+        parser.add_argument(
             "-w",
             "--workers",
             metavar="N",
@@ -133,6 +137,7 @@ class Main:
             self.args.update,
             self.args.force,
             self.args.algo,
+            self.args.skip_symlinks
         )
 
         # start indexing


### PR DESCRIPTION
I had trouble using chkbit because I happened to have some symlinks pointing up to a higher folder, causing chkbit to loop endlessly. This PR adds a `--skip-symlinks` option to avoid this, or any other unexpected results due to symlinks.

Note also, that to get this to work locally, I had to make an `__init__.py` file which is not present in the repo, nor this PR, due to the `_*` in the `.gitignore`. I'm not sure if this is intentional, or some Python version difference or something else I don't understand. Let me know if you'd like me to include the `__init__.py` in this PR.
