### PR TITLE
feature: add --KeepMissing option to chkbit update command.

### DIFF
--- a/cmd/chkbit/main.go
+++ b/cmd/chkbit/main.go
@@ -80,6 +80,7 @@ type CLI struct {
 		Paths        []string `arg:"" name:"paths" help:"directories to update"`
 		SkipExisting bool     `short:"s" help:"only add new and modified files, do not check existing (quicker)"`
 		Force        bool     `help:"force update of damaged items (advanced usage only)"`
+		NoDelete     bool     `help:"do not delete missing files from the index (default is to remove them)"`
 	} `cmd:"" help:"add and update modified files, also checking existing ones (see chkbit update -h)"`
 
 	Init struct {
@@ -327,6 +328,7 @@ func (m *Main) runCmd(command string, cli CLI) int {
 		m.context.UpdateIndex = true
 		m.context.UpdateSkipCheck = cli.Update.SkipExisting
 		m.context.ForceUpdateDmg = cli.Update.Force
+		m.context.NoDelete = cli.Update.NoDelete
 		m.log("chkbit update " + strings.Join(pathList, ", "))
 	case cmdShowIgnored:
 		pathList = cli.ShowIgnored.Paths

--- a/cmd/chkbit/main.go
+++ b/cmd/chkbit/main.go
@@ -80,7 +80,7 @@ type CLI struct {
 		Paths        []string `arg:"" name:"paths" help:"directories to update"`
 		SkipExisting bool     `short:"s" help:"only add new and modified files, do not check existing (quicker)"`
 		Force        bool     `help:"force update of damaged items (advanced usage only)"`
-		NoDelete     bool     `help:"do not delete missing files from the index (default is to remove them)"`
+		KeepMissing  bool     `help:"keep missing files in the index"`
 	} `cmd:"" help:"add and update modified files, also checking existing ones (see chkbit update -h)"`
 
 	Init struct {
@@ -328,7 +328,7 @@ func (m *Main) runCmd(command string, cli CLI) int {
 		m.context.UpdateIndex = true
 		m.context.UpdateSkipCheck = cli.Update.SkipExisting
 		m.context.ForceUpdateDmg = cli.Update.Force
-		m.context.NoDelete = cli.Update.NoDelete
+		m.context.KeepMissing = cli.Update.KeepMissing
 		m.log("chkbit update " + strings.Join(pathList, ", "))
 	case cmdShowIgnored:
 		pathList = cli.ShowIgnored.Paths

--- a/context.go
+++ b/context.go
@@ -15,7 +15,7 @@ type Context struct {
 	UpdateIndex        bool // add and update hashes
 	UpdateSkipCheck    bool // do not check existing hashes when updating
 	ShowIgnoredOnly    bool // print ignored files
-	NoDelete           bool // skip deletion of missing files from index when updating
+	KeepMissing        bool // keep missing files in index when updating
 	LogDeleted         bool // output deleted files and directories
 	IncludeDot         bool // include dot files
 	ForceUpdateDmg     bool

--- a/context.go
+++ b/context.go
@@ -15,6 +15,7 @@ type Context struct {
 	UpdateIndex        bool // add and update hashes
 	UpdateSkipCheck    bool // do not check existing hashes when updating
 	ShowIgnoredOnly    bool // print ignored files
+	NoDelete           bool // skip deletion of missing files from index when updating
 	LogDeleted         bool // output deleted files and directories
 	IncludeDot         bool // include dot files
 	ForceUpdateDmg     bool

--- a/index.go
+++ b/index.go
@@ -170,7 +170,7 @@ func (i *Index) checkFix(forceUpdateDmg bool) {
 	for name := range i.cur {
 		if _, ok := i.new[name]; !ok {
 			// file missing
-			if i.context.NoDelete {
+			if i.context.KeepMissing {
 				// preserve old entry
 				i.new[name] = i.cur[name]
 			} else {
@@ -190,7 +190,7 @@ func (i *Index) checkFix(forceUpdateDmg bool) {
 	for _, name := range i.curDirList {
 		if !m[name] {
 			// directory missing
-			if i.context.NoDelete {
+			if i.context.KeepMissing {
 				// preserve old directory
 				i.newDirList = append(i.newDirList, name)
 			} else {

--- a/index.go
+++ b/index.go
@@ -169,9 +169,15 @@ func (i *Index) checkFix(forceUpdateDmg bool) {
 	// track deleted files
 	for name := range i.cur {
 		if _, ok := i.new[name]; !ok {
-			i.modified = true
-			if i.context.LogDeleted {
-				i.logFile(StatusDeleted, name)
+			// file missing
+			if i.context.NoDelete {
+				// preserve old entry
+				i.new[name] = i.cur[name]
+			} else {
+				i.modified = true
+				if i.context.LogDeleted {
+					i.logFile(StatusDeleted, name)
+				}
 			}
 		}
 	}
@@ -183,9 +189,15 @@ func (i *Index) checkFix(forceUpdateDmg bool) {
 	}
 	for _, name := range i.curDirList {
 		if !m[name] {
-			i.modified = true
-			if i.context.LogDeleted {
-				i.logDir(StatusDeleted, name+"/")
+			// directory missing
+			if i.context.NoDelete {
+				// preserve old directory
+				i.newDirList = append(i.newDirList, name)
+			} else {
+				i.modified = true
+				if i.context.LogDeleted {
+					i.logDir(StatusDeleted, name+"/")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This feature adds support for not deleting missing files or directories from the index (default is to remove them). This is for cases where the mount point might to temprary offline and you don't want to reindex them again when it is online and are using SkipExisting features, thus saves a lot of time if the repo exceeds a couple of terrabyte for those specific directores/files.