### PR TITLE
Fix: update Hashfile function to return mtime and size as well.

### DIFF
--- a/hashfile.go
+++ b/hashfile.go
@@ -14,7 +14,7 @@ import (
 
 const BLOCKSIZE = 2 << 10 << 7 // kb
 
-func Hashfile(path string, hashAlgo string, perfMonBytes func(int64)) (string, error) {
+func Hashfile(path string, hashAlgo string, perfMonBytes func(int64)) (string, int64, int64, error) {
 	var h hash.Hash
 	switch hashAlgo {
 	case "md5":
@@ -24,20 +24,28 @@ func Hashfile(path string, hashAlgo string, perfMonBytes func(int64)) (string, e
 	case "blake3":
 		h = blake3.New(32, nil)
 	default:
-		return "", errors.New("algo '" + hashAlgo + "' is unknown.")
+		return "", 0, 0, errors.New("algo '" + hashAlgo + "' is unknown.")
 	}
 
 	file, err := os.Open(path)
 	if err != nil {
-		return "", err
+		return "", 0, 0, err
 	}
 	defer file.Close()
+
+	// Get file info AFTER opening to avoid race condition
+	var info os.FileInfo
+	if info, err = file.Stat(); err != nil {
+		return "", 0, 0, err
+	}
+	mtime := int64(info.ModTime().UnixNano() / 1e6) // convert to ms
+	size := info.Size()
 
 	buf := make([]byte, BLOCKSIZE)
 	for {
 		bytesRead, err := file.Read(buf)
 		if err != nil && err != io.EOF {
-			return "", err
+			return "", 0, 0, err
 		}
 		if bytesRead == 0 {
 			break
@@ -47,7 +55,7 @@ func Hashfile(path string, hashAlgo string, perfMonBytes func(int64)) (string, e
 			perfMonBytes(int64(bytesRead))
 		}
 	}
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return hex.EncodeToString(h.Sum(nil)), mtime, size, nil
 }
 
 func hashMd5(data []byte) string {

--- a/index.go
+++ b/index.go
@@ -214,11 +214,8 @@ func (i *Index) mtimeChanged(name string, ii idxInfo) bool {
 
 func (i *Index) calcFile(name string, algo string) (*idxInfo, error) {
 	path := slpath.Join(i.path, name)
-	mtime, size, err := getMtS(path)
-	if err != nil {
-		return nil, err
-	}
-	hash, err := Hashfile(path, algo, i.context.perfMonBytes)
+
+	hash, mtime, size, err := Hashfile(path, algo, i.context.perfMonBytes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Possible race condition when the file is being updated by different process while simultaneously being checksummed by chkbit. (discovered and tested on macos, gave quite a scare there, might need some testing on other platforms)