### PR TITLE
Update so that once chkbit has started hashing files ctrl+c will signal to stop

### DIFF
--- a/context.go
+++ b/context.go
@@ -44,10 +44,14 @@ type Context struct {
 }
 
 func (context *Context) Abort() {
+	context.mutex.Lock()
+	defer context.mutex.Unlock()
 	context.doAbort = true
 }
 
 func (context *Context) DidAbort() bool {
+	context.mutex.Lock()
+	defer context.mutex.Unlock()
 	return context.doAbort
 }
 
@@ -185,7 +189,7 @@ func (context *Context) Process(pathList []string) {
 
 func (context *Context) scanDir(root string, parentIgnore *Ignore, depth int) {
 
-	if context.doAbort {
+	if context.DidAbort() {
 		return
 	}
 

--- a/index.go
+++ b/index.go
@@ -89,6 +89,10 @@ func (i *Index) logDir(stat Status, name string) {
 
 func (i *Index) calcHashes(ignore *Ignore) {
 	for _, name := range i.files {
+		if i.context.DidAbort() {
+			return
+		}
+
 		if ignore.shouldIgnore(name) {
 			if !ignore.context.isChkbitFile(name) {
 				i.logFile(StatusIgnore, name)
@@ -135,6 +139,10 @@ func (i *Index) showIgnoredOnly(ignore *Ignore) {
 
 func (i *Index) checkFix(forceUpdateDmg bool) {
 	for name, b := range i.new {
+		if i.context.DidAbort() {
+			return
+		}
+
 		if a, ok := i.cur[name]; !ok {
 			i.logFile(StatusNew, name)
 			i.modified = true

--- a/worker.go
+++ b/worker.go
@@ -10,7 +10,7 @@ type WorkItem struct {
 func (context *Context) runWorker(_ int) {
 	for {
 		item := <-context.WorkQueue
-		if item == nil || context.doAbort {
+		if item == nil || context.DidAbort() {
 			break
 		}
 


### PR DESCRIPTION
I noticed when using chkbit if I tried to "ctrl+c" it would never stop. I would have to do a kill on the process to stop it.

This is my attempt to update the code enough a user can cancel.